### PR TITLE
Change EINTR handling to return error and indicate timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
         luarocks install time-clock
         luarocks install os-pipe
         luarocks install fork
-        luarocks install signal
     -
       name: Run Test
       run: |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ luarocks install io-wait
 
 the functions/methods are return the error object created by https://github.com/mah0x211/lua-errno module.
 
-NOTE: when `EINTR` is occurred, it will be retried to call the system call.
+NOTE: when `EINTR` is occurred, it return `err` and `timeout` as `true`.
 
 
 ## fd, err, timeout, hup = wait.readable( [fd [, sec [, ...]]] )

--- a/test/wait_test.lua
+++ b/test/wait_test.lua
@@ -4,7 +4,6 @@ local wait = require('io.wait')
 local gettime = require('time.clock').gettime
 local pipe = require('os.pipe')
 local fork = require('fork')
-require('signal')
 
 local r, w, perr = pipe(true)
 assert(r, perr)
@@ -39,22 +38,25 @@ do
     assert.is_nil(hup)
     assert(t > 0.5 and t < 1)
 
-    -- test that return timeout=true even if eintr error is occurred
-    local p = assert(fork())
-    if p:is_child() then
-        os.exit(0)
+    if tonumber(_G._VERSION:match('%d%.%d')) < 5.4 then
+        -- in Lua 5.3 and earlier, wait.readable() may return EINTR error
+        -- test that return timeout=true even if eintr error is occurred
+        local p = assert(fork())
+        if p:is_child() then
+            os.exit(0)
+        end
+        t = gettime()
+        fd, err, timeout, hup = wait.readable(r:fd(), 1)
+        t = gettime() - t
+        assert.is_nil(fd)
+        assert.match(err, 'EINTR')
+        assert.is_true(timeout)
+        assert.is_nil(hup)
+        assert(t < 1)
     end
-    t = gettime()
-    fd, err, timeout, hup = wait.readable(r:fd(), 0.5)
-    t = gettime() - t
-    assert.is_nil(fd)
-    assert(not err, err)
-    assert.is_true(timeout)
-    assert.is_nil(hup)
-    assert(t > 0.5 and t < 1)
 
     -- test that return no error even if eintr error is occurred
-    p = assert(fork())
+    local p = assert(fork())
     if p:is_child() then
         os.exit(0)
     end


### PR DESCRIPTION
This pull request simplifies the handling of system calls interrupted by `EINTR` in the `wait` module by treating them as timeouts and removing redundant code. Key changes include updating the behavior of the `poll` function, refactoring the C implementation to eliminate unnecessary helper functions, and updating the documentation and tests accordingly.

### Behavior Changes:
* Updated the behavior of `poll_lua` to treat `EINTR` errors as timeouts, returning `err` and `timeout` as `true` instead of retrying the system call. (`src/wait.c`, [src/wait.cR62-R67](diffhunk://#diff-1cf2056af8a94756bfe061e7effc0b7181dc132a4c046e222a8085cde3e6434fR62-R67))
* Modified the README to reflect the new behavior, clarifying that `EINTR` results in `err` and `timeout` being returned. (`README.md`, [README.mdL19-R19](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19))

### Code Simplification:
* Removed the `poll_with_timeout_lua` and `poll_without_timeout_lua` helper functions, simplifying the `poll_lua` implementation to directly call `poll`. (`src/wait.c`, [[1]](diffhunk://#diff-1cf2056af8a94756bfe061e7effc0b7181dc132a4c046e222a8085cde3e6434fL38-L95) [[2]](diffhunk://#diff-1cf2056af8a94756bfe061e7effc0b7181dc132a4c046e222a8085cde3e6434fL107-R48)
* Removed the inclusion of the unnecessary `<time.h>` header. (`src/wait.c`, [src/wait.cL29](diffhunk://#diff-1cf2056af8a94756bfe061e7effc0b7181dc132a4c046e222a8085cde3e6434fL29))

### Test Updates:
* Updated the test case in `wait_test.lua` to verify the new behavior for `EINTR`, ensuring that `err` matches `EINTR`, `timeout` is `true`, and the elapsed time is less than the timeout value. (`test/wait_test.lua`, [test/wait_test.luaL51-R54](diffhunk://#diff-62ccd67116a24d0f8e96c45fb0144c0f3dca1b8ea1fb968c75418b009a260d93L51-R54))